### PR TITLE
Send plug telemetry events

### DIFF
--- a/lib/plug/amqp.ex
+++ b/lib/plug/amqp.ex
@@ -158,6 +158,6 @@ defmodule Plug.AMQP do
     exit({value, call})
   end
 
-  defp maybe_send_resp(%Plug.Conn{state: :set} = conn), do: Plug.Conn.send_resp(conn)
-  defp maybe_send_resp(%Plug.Conn{} = conn), do: conn
+  defp maybe_send_resp(conn = %Plug.Conn{state: :set}), do: Plug.Conn.send_resp(conn)
+  defp maybe_send_resp(conn = %Plug.Conn{}), do: conn
 end

--- a/lib/plug/amqp.ex
+++ b/lib/plug/amqp.ex
@@ -83,7 +83,9 @@ defmodule Plug.AMQP do
     )
 
     try do
-      plug.call(conn, plug_opts)
+      conn
+      |> plug.call(plug_opts)
+      |> maybe_send_resp()
     catch
       kind, reason ->
         :telemetry.execute(
@@ -155,4 +157,7 @@ defmodule Plug.AMQP do
   defp exit_on_error(:exit, value, _stack, call) do
     exit({value, call})
   end
+
+  defp maybe_send_resp(%Plug.Conn{state: :set} = conn), do: Plug.Conn.send_resp(conn)
+  defp maybe_send_resp(%Plug.Conn{} = conn), do: conn
 end

--- a/lib/plug/amqp/consumer_producer.ex
+++ b/lib/plug/amqp/consumer_producer.ex
@@ -31,9 +31,6 @@ defmodule Plug.AMQP.ConsumerProducer do
   """
   use GenServer
 
-  # TODO: Emit `plug_adapter.request.start`, `plug_adapter.request.stop` and
-  # `plug_adapter.request.failure` telemetry events on every request.
-
   alias AMQP.{Basic, Channel, Connection}
   alias __MODULE__, as: State
 

--- a/lib/plug/amqp/consumer_producer.ex
+++ b/lib/plug/amqp/consumer_producer.ex
@@ -290,6 +290,39 @@ defmodule Plug.AMQP.ConsumerProducer do
   # Server - Handle Info - Request Handlers
   #
 
+  # A request handler has a response sent back
+  def handle_info(
+        {:send_resp, caller, payload, headers},
+        state = %State{index: index, opts: opts}
+      ) do
+    case Enum.find(index, fn {_k, v} -> match?({%Task{pid: ^caller}, _meta}, v) end) do
+      nil ->
+        Logger.warn("Response sent from an unknown task")
+
+      {_ref, {_task, req_meta = %{reply_to: routing_key}}} ->
+        resp_meta = [
+          correlation_id: req_meta.correlation_id || req_meta.message_id,
+          headers: to_arguments(headers),
+          persistent: req_meta.persistent,
+          timestamp: DateTime.utc_now() |> DateTime.to_unix()
+        ]
+
+        case amqp(opts).publish(state.producer_chan, "", routing_key, payload, resp_meta) do
+          :ok ->
+            :telemetry.execute([:plug_amqp, :consumer_producer, :outcoming_message], %{
+              size: byte_size(payload)
+            })
+
+          {:error, reason} ->
+            id = get_request_id(req_meta)
+            Logger.error("Error sending response of message #{id}: #{inspect(reason)}.")
+            nack_or_reject(opts, state.consumer_chan, req_meta)
+        end
+    end
+
+    {:noreply, state}
+  end
+
   # A request handler finish successfully
   def handle_info({ref, :ok}, state = %State{index: index, opts: opts})
       when is_reference(ref) do
@@ -384,43 +417,6 @@ defmodule Plug.AMQP.ConsumerProducer do
     nack_or_reject(opts, state.consumer_chan, meta)
 
     {:noreply, delete_index_entry(state, ref)}
-  end
-
-  #
-  # Server - Handle Cast
-  #
-
-  @impl true
-  def handle_info(
-        {:send_resp, caller, payload, headers},
-        state = %State{index: index, opts: opts}
-      ) do
-    case Enum.find(index, fn {_k, v} -> match?({%Task{pid: ^caller}, _meta}, v) end) do
-      nil ->
-        Logger.warn("Response sent from an unknown task")
-
-      {_ref, {_task, req_meta = %{reply_to: routing_key}}} ->
-        resp_meta = [
-          correlation_id: req_meta.correlation_id || req_meta.message_id,
-          headers: to_arguments(headers),
-          persistent: req_meta.persistent,
-          timestamp: DateTime.utc_now() |> DateTime.to_unix()
-        ]
-
-        case amqp(opts).publish(state.producer_chan, "", routing_key, payload, resp_meta) do
-          :ok ->
-            :telemetry.execute([:plug_amqp, :consumer_producer, :outcoming_message], %{
-              size: byte_size(payload)
-            })
-
-          {:error, reason} ->
-            id = get_request_id(req_meta)
-            Logger.error("Error sending response of message #{id}: #{inspect(reason)}.")
-            nack_or_reject(opts, state.consumer_chan, req_meta)
-        end
-    end
-
-    {:noreply, state}
   end
 
   #

--- a/lib/plug/amqp/consumer_producer.ex
+++ b/lib/plug/amqp/consumer_producer.ex
@@ -133,7 +133,7 @@ defmodule Plug.AMQP.ConsumerProducer do
   @doc "Sends a response from a request handler"
   @spec send_resp(GenServer.server(), payload(), headers()) :: :ok
   def send_resp(server, payload, headers \\ []) do
-    GenServer.cast(server, {:send_resp, self(), payload, headers})
+    send(server, {:send_resp, self(), payload, headers})
   end
 
   #
@@ -391,7 +391,7 @@ defmodule Plug.AMQP.ConsumerProducer do
   #
 
   @impl true
-  def handle_cast(
+  def handle_info(
         {:send_resp, caller, payload, headers},
         state = %State{index: index, opts: opts}
       ) do

--- a/test/plug/amqp/handler_test.exs
+++ b/test/plug/amqp/handler_test.exs
@@ -36,8 +36,7 @@ defmodule Plug.AMQPTest do
   end
 
   test "handle message that would raise but still sends a resp" do
-    Plug.AMQP
-    |> Task.start(:handle, [
+    Task.start(Plug.AMQP, :handle, [
       self(),
       "ping",
       [{"amqp-routing-key", "does.not.exist"}],

--- a/test/plug/amqp/handler_test.exs
+++ b/test/plug/amqp/handler_test.exs
@@ -1,0 +1,49 @@
+defmodule Plug.AMQPTest do
+  use ExUnit.Case, async: true
+
+  defmodule MyPlug do
+    def call(%Plug.Conn{path_info: ["foo", "bar"]} = conn, _) do
+      Plug.Conn.resp(conn, 200, "pong")
+    end
+
+    def call(%Plug.Conn{path_info: ["force", "bar"]} = conn, _) do
+      conn
+      |> Plug.Conn.resp(200, "pong")
+      |> Plug.Conn.send_resp()
+    end
+
+    # simulate some error handler that writes response
+    def call(conn, _) do
+      conn
+      |> Plug.Conn.resp(200, "ERROR")
+      |> Plug.Conn.send_resp()
+
+      raise "something"
+    end
+  end
+
+  test "handle routed message" do
+    assert :ok = Plug.AMQP.handle(self(), "ping", [{"amqp-routing-key", "foo.bar"}], plug: MyPlug)
+
+    assert_receive {:send_resp, _, "pong", _}
+  end
+
+  test "handle routed message, force send response" do
+    assert :ok =
+             Plug.AMQP.handle(self(), "ping", [{"amqp-routing-key", "force.bar"}], plug: MyPlug)
+
+    assert_receive {:send_resp, _, "pong", _}
+  end
+
+  test "handle message that would raise but still sends a resp" do
+    Plug.AMQP
+    |> Task.start(:handle, [
+      self(),
+      "ping",
+      [{"amqp-routing-key", "does.not.exist"}],
+      [plug: MyPlug]
+    ])
+
+    assert_receive {:send_resp, _, "ERROR", _}
+  end
+end

--- a/test/plug/amqp/handler_test.exs
+++ b/test/plug/amqp/handler_test.exs
@@ -2,11 +2,11 @@ defmodule Plug.AMQPTest do
   use ExUnit.Case, async: true
 
   defmodule MyPlug do
-    def call(%Plug.Conn{path_info: ["foo", "bar"]} = conn, _) do
+    def call(conn = %Plug.Conn{path_info: ["foo", "bar"]}, _) do
       Plug.Conn.resp(conn, 200, "pong")
     end
 
-    def call(%Plug.Conn{path_info: ["force", "bar"]} = conn, _) do
+    def call(conn = %Plug.Conn{path_info: ["force", "bar"]}, _) do
       conn
       |> Plug.Conn.resp(200, "pong")
       |> Plug.Conn.send_resp()

--- a/test/plug/amqp/telemetry_test.exs
+++ b/test/plug/amqp/telemetry_test.exs
@@ -1,0 +1,95 @@
+defmodule Plug.AMQP.TelemetryTest do
+  use ExUnit.Case, async: true
+
+  def attach_telemetry() do
+    unique_name = :"PID#{System.unique_integer()}"
+    Process.register(self(), unique_name)
+
+    for suffix <- [:start, :stop, :exception] do
+      :telemetry.attach(
+        {suffix, unique_name},
+        [:plug_adapter, :call, suffix],
+        fn event, measurements, metadata, :none ->
+          send(unique_name, {:event, event, measurements, metadata})
+        end,
+        :none
+      )
+    end
+
+    on_exit(fn ->
+      for suffix <- [:start, :stop, :exception] do
+        :telemetry.detach({suffix, unique_name})
+      end
+    end)
+  end
+
+  defmodule MyPlug do
+    def call(conn = %{path_info: ["telemetry_stop"]}, _) do
+      Plug.Conn.send_resp(conn, 200, "STOP")
+    end
+
+    def call(conn = %{path_info: ["telemetry_exception"]}, _) do
+      Plug.Conn.send_resp(conn, 200, "STOP")
+      raise "oops"
+    end
+  end
+
+  test "emits telemetry events for start/stop" do
+    attach_telemetry()
+
+    Plug.AMQP
+    |> Task.async(:handle, [
+      self(),
+      "ping",
+      [{"amqp-routing-key", "telemetry_stop"}],
+      [plug: MyPlug]
+    ])
+
+    assert_receive {:event, [:plug_adapter, :call, :start], %{system_time: _},
+                    %{
+                      adapter: :plug_amqp,
+                      conn: %{request_path: "/telemetry_stop"},
+                      plug: MyPlug
+                    }}
+
+    assert_receive {:send_resp, _, "STOP", _}
+
+    assert_receive {:event, [:plug_adapter, :call, :stop], %{duration: _},
+                    %{
+                      adapter: :plug_amqp,
+                      conn: %{request_path: "/telemetry_stop", status: 200},
+                      plug: MyPlug
+                    }}
+
+    refute_received {:event, [:plug_adapter, :call, :exception], _, _}
+  end
+
+  test "emits telemetry events for start/exception" do
+    attach_telemetry()
+
+    Plug.AMQP
+    |> Task.start(:handle, [
+      self(),
+      "ping",
+      [{"amqp-routing-key", "telemetry_exception"}],
+      [plug: MyPlug]
+    ])
+
+    assert_receive {:event, [:plug_adapter, :call, :start], %{system_time: _},
+                    %{
+                      adapter: :plug_amqp,
+                      conn: %{request_path: "/telemetry_exception"},
+                      plug: MyPlug
+                    }}
+
+    assert_receive {:event, [:plug_adapter, :call, :exception], %{duration: _},
+                    %{
+                      adapter: :plug_amqp,
+                      reason: %RuntimeError{},
+                      conn: %{request_path: "/telemetry_exception"},
+                      plug: MyPlug
+                    }}
+
+    refute_received {:event, [:plug_adapter, :call, :stop], _, _}
+  end
+end

--- a/test/plug/amqp/telemetry_test.exs
+++ b/test/plug/amqp/telemetry_test.exs
@@ -1,7 +1,7 @@
 defmodule Plug.AMQP.TelemetryTest do
   use ExUnit.Case, async: true
 
-  def attach_telemetry() do
+  def attach_telemetry do
     unique_name = :"PID#{System.unique_integer()}"
     Process.register(self(), unique_name)
 

--- a/test/plug/amqp/telemetry_test.exs
+++ b/test/plug/amqp/telemetry_test.exs
@@ -53,7 +53,7 @@ defmodule Plug.AMQP.TelemetryTest do
                       plug: MyPlug
                     }}
 
-    refute_received {:event, [:plug_adapter, :call, :exception], %{plug: MyPlug}, _}
+    refute_received {:event, [:plug_adapter, :call, :exception], _, %{plug: MyPlug}}
   end
 
   test "emits telemetry events for start/exception" do
@@ -81,6 +81,6 @@ defmodule Plug.AMQP.TelemetryTest do
                       plug: MyPlug
                     }}
 
-    refute_received {:event, [:plug_adapter, :call, :stop], %{plug: MyPlug}, _}
+    refute_received {:event, [:plug_adapter, :call, :stop], _, %{plug: MyPlug}}
   end
 end


### PR DESCRIPTION
Fixes #2 
Fixes #1

Also fixes sending a resp when the plug doesn't explicitly call `Plug.Conn.send_resp`.