### PR TITLE
Fix use of send_resp whe no client is waiting for response

### DIFF
--- a/lib/plug/amqp/consumer_producer.ex
+++ b/lib/plug/amqp/consumer_producer.ex
@@ -299,6 +299,10 @@ defmodule Plug.AMQP.ConsumerProducer do
       nil ->
         Logger.warn("Response sent from an unknown task")
 
+      {_ref, {_task, req_meta = %{reply_to: :undefined}}} ->
+        id = get_request_id(req_meta)
+        Logger.info("Request #{id} expect no response")
+
       {_ref, {_task, req_meta = %{reply_to: routing_key}}} ->
         resp_meta = [
           correlation_id: req_meta.correlation_id || req_meta.message_id,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PlugAmqp.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.5.1"
   @description "A Plug adapter for AMQP"
 
   def project do


### PR DESCRIPTION
Right now, if a server is using `send_resp` to answer a request but the client does not specify any `reply-to` header the server crashes. This patch fixes this issue.